### PR TITLE
fix: reset transaction data after popup was closed

### DIFF
--- a/packages/shared/src/lib/core/wallet/actions/send/sendOutputFromStardust.ts
+++ b/packages/shared/src/lib/core/wallet/actions/send/sendOutputFromStardust.ts
@@ -4,6 +4,7 @@ import { checkActiveProfileAuth, getIsActiveLedgerProfile } from '@core/profile'
 import { Output } from '@core/wallet/types'
 import { validateSendConfirmation } from '@core/wallet/utils'
 import { signAndSendStardustTransaction } from './signAndSendStardustTransaction'
+import { resetNewTokenTransactionData } from '@core/wallet/stores'
 
 export async function sendOutputFromStardust(
     output: Output,
@@ -20,6 +21,7 @@ export async function sendOutputFromStardust(
         async () => {
             await signAndSendStardustTransaction(output, account)
             callback()
+            resetNewTokenTransactionData()
         },
         { stronghold: true, ledger: false }
     )

--- a/packages/shared/src/lib/core/wallet/actions/send/signAndSendStardustTransaction.ts
+++ b/packages/shared/src/lib/core/wallet/actions/send/signAndSendStardustTransaction.ts
@@ -1,7 +1,6 @@
 import { IAccountState, updateSelectedAccount } from '@core/account'
 import { updateNftInAllAccountNfts } from '@core/nfts/actions'
 import { DEFAULT_TRANSACTION_OPTIONS, OUTPUT_TYPE_NFT } from '@core/wallet/constants'
-import { resetNewTokenTransactionData } from '@core/wallet/stores'
 import { Output } from '@core/wallet/types'
 import { processAndAddToActivities } from '@core/wallet/utils'
 
@@ -13,8 +12,6 @@ export async function signAndSendStardustTransaction(output: Output, account: IA
         if (output.type === OUTPUT_TYPE_NFT) {
             updateNftInAllAccountNfts(account.index, output.nftId, { isSpendable: false })
         }
-
-        resetNewTokenTransactionData()
 
         await processAndAddToActivities(transaction, account)
         updateSelectedAccount({ isTransferring: false })


### PR DESCRIPTION
## Summary

Fixes the type error thrown when sending a stardust transaction.

...

## Testing

Send a L1 transaction

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [x] Linux
    -   [ ] Windows

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
