### PR TITLE
fix: menu item light mode style

### DIFF
--- a/packages/shared/src/components/atoms/MenuItem.svelte
+++ b/packages/shared/src/components/atoms/MenuItem.svelte
@@ -84,7 +84,7 @@
 
             @each $variant, $color in $variants {
                 &.#{$variant} {
-                    @apply hover:bg-#{$color}-50 hover:bg-#{$color}-800 dark:hover:bg-opacity-20;
+                    @apply hover:bg-#{$color}-50 dark:hover:bg-#{$color}-800 dark:hover:bg-opacity-20;
                 }
             }
         }


### PR DESCRIPTION
## Summary

There was a missing "dark:" selector in MenuItem style and it was preventing the correct style in light mode to be shown for it, this PR fixes it.

## Testing

### Platforms
-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
