### PR TITLE
fix: adds modules routes in tailwind config content field

### DIFF
--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -15,7 +15,7 @@ const NODE_MODULES_ROUTES = [
 module.exports = {
     content: [
         ...SHARED_CONTENT_ROUTES,
-        NODE_MODULES_ROUTES,
+        ...NODE_MODULES_ROUTES,
         ...(IS_DESKTOP ? DESKTOP_CONTENT_ROUTES : MOBILE_CONTENT_ROUTES),
     ],
     presets: [require('@bloomwalletio/ui/tailwind-preset')],

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -3,13 +3,21 @@ const colors = require('tailwindcss/colors')
 /* Utilities */
 const pxToRem = (px, base = 16) => `${px / base}rem`
 
-const IS_DESKOP = process.env.PLATFORM === 'desktop'
+const IS_DESKTOP = process.env.PLATFORM === 'desktop'
 const SHARED_CONTENT_ROUTES = ['../shared/**/*.svelte', '../shared/**/*.scss']
 const DESKTOP_CONTENT_ROUTES = ['../desktop/**/*.svelte']
 const MOBILE_CONTENT_ROUTES = ['../mobile/**/*.svelte']
+const NODE_MODULES_ROUTES = [
+    '../../node_modules/flowbite-svelte/**/*.{html,js,svelte,ts}',
+    '../../node_modules/@bloomwalletio/ui/**/*.{html,js,svelte,ts}',
+]
 
 module.exports = {
-    content: [...SHARED_CONTENT_ROUTES, ...(IS_DESKOP ? DESKTOP_CONTENT_ROUTES : MOBILE_CONTENT_ROUTES)],
+    content: [
+        ...SHARED_CONTENT_ROUTES,
+        NODE_MODULES_ROUTES,
+        ...(IS_DESKTOP ? DESKTOP_CONTENT_ROUTES : MOBILE_CONTENT_ROUTES),
+    ],
     presets: [require('@bloomwalletio/ui/tailwind-preset')],
     safelist: [
         {


### PR DESCRIPTION
## Summary

Tailwind needs to know which files to look for classes when generating its stylesheet, so this PR adds `flowbite-svelte` and `@bloomwalletio/ui` routes to the `content` field in `tailwind.config.js`

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
