### PR TITLE
fix: updates package name in webpack managedPaths

### DIFF
--- a/packages/desktop/webpack.config.ts
+++ b/packages/desktop/webpack.config.ts
@@ -225,7 +225,7 @@ const webpackConfig: Configuration[] = [
             },
         },
         snapshot: {
-            managedPaths: [/^(.+?[\\/]node_modules[\\/](?!(@bloom-labs[\\/]ui))(@.+?[\\/])?.+?)[\\/]/],
+            managedPaths: [/^(.+?[\\/]node_modules[\\/](?!(@bloomwalletio[\\/]ui))(@.+?[\\/])?.+?)[\\/]/],
         },
     },
     {


### PR DESCRIPTION
## Summary

The package name has changed, so the regex for the managedPaths inside webpack config also needed to be updated.

The hot reloading now should work for bloom-ui changing locally.

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
