### PR TITLE
fix: darkmode class strategy

### DIFF
--- a/packages/desktop/App.svelte
+++ b/packages/desktop/App.svelte
@@ -62,7 +62,11 @@
 
     $: $nftDownloadQueue, downloadNextNftInQueue()
 
-    $: Platform.updateTheme($appSettings.theme)
+    $: if ($appSettings.darkMode) {
+        document.documentElement.classList.add('dark')
+    } else {
+        document.documentElement.classList.remove('dark')
+    }
 
     let splash = true
     let settings = false

--- a/packages/desktop/lib/electron/apis/electron.api.ts
+++ b/packages/desktop/lib/electron/apis/electron.api.ts
@@ -228,9 +228,6 @@ export default {
             ) as IFeatureFlag
         return feature?.enabled ?? false
     },
-    updateTheme(theme: string): Promise<void> {
-        return ipcRenderer.invoke('update-theme', theme)
-    },
     startLedgerProcess(): void {
         return ipcRenderer.send('start-ledger-process')
     },

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -29,6 +29,7 @@
     },
     "dependencies": {
         "@amplitude/analytics-node": "1.3.1",
+        "@csstools/postcss-is-pseudo-class": "4.0.0",
         "@ethereumjs/rlp": "4.0.1",
         "@ethereumjs/tx": "4.1.2",
         "@ethereumjs/util": "8.0.6",

--- a/packages/desktop/postcss.config.js
+++ b/packages/desktop/postcss.config.js
@@ -4,6 +4,7 @@ const mode = process.env.NODE_ENV || 'development'
 
 module.exports = {
     plugins: [
+        require('@csstools/postcss-is-pseudo-class'),
         require('tailwindcss')('./../shared/tailwind.config.js'),
         require('postcss-url')({
             url:

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -48,7 +48,7 @@
         "postcss-cli": "10.1.0",
         "sass": "1.63.6",
         "svelte-loader": "3.1.9",
-        "tailwindcss": "3.3.2",
+        "tailwindcss": "3.3.3",
         "tslib": "2.6.1",
         "valid-url": "1.0.9",
         "zxcvbn": "4.4.2"

--- a/packages/shared/src/components/inputs/DateTimePicker.svelte
+++ b/packages/shared/src/components/inputs/DateTimePicker.svelte
@@ -92,31 +92,27 @@
 </Tooltip>
 
 <style lang="scss">
-    @media (prefers-color-scheme: dark) {
-        :global(.datetime-picker-colors) {
-            --sdt-color: theme('colors.white');
-            --sdt-btn-bg-hover: theme('colors.gray.800');
-            --sdt-btn-bg-hover: theme('colors.gray.800');
-            --sdt-btn-header-bg-hover: theme('colors.gray.800');
-            --sdt-clock-bg: theme('colors.gray.800');
-            --sdt-clock-bg-minute: theme('colors.gray.800');
-        }
+    :global(.dark .datetime-picker-colors) {
+        --sdt-color: theme('colors.white');
+        --sdt-btn-bg-hover: theme('colors.gray.800');
+        --sdt-btn-bg-hover: theme('colors.gray.800');
+        --sdt-btn-header-bg-hover: theme('colors.gray.800');
+        --sdt-clock-bg: theme('colors.gray.800');
+        --sdt-clock-bg-minute: theme('colors.gray.800');
     }
 
-    @media (prefers-color-scheme: light) {
-        :global(.datetime-picker-colors) {
-            --sdt-primary: theme('colors.blue.500');
-            --sdt-color: theme('colors.gray.600');
-            --sdt-color-selected: theme('colors.white');
-            --sdt-bg-main: none;
-            --sdt-bg-today: var(--sdt-primary);
-            --sdt-today-color: theme('colors.white');
-            --sdt-btn-bg-hover: theme('colors.gray.200');
-            --sdt-btn-header-bg-hover: theme('colors.gray.200');
-            --sdt-clock-bg: theme('colors.gray.200');
-            --sdt-clock-bg-minute: theme('colors.gray.200');
-            --sdt-clock-bg-shadow: none;
-            --sdt-shadow: none;
-        }
+    :global(.datetime-picker-colors) {
+        --sdt-primary: theme('colors.blue.500');
+        --sdt-color: theme('colors.gray.600');
+        --sdt-color-selected: theme('colors.white');
+        --sdt-bg-main: none;
+        --sdt-bg-today: var(--sdt-primary);
+        --sdt-today-color: theme('colors.white');
+        --sdt-btn-bg-hover: theme('colors.gray.200');
+        --sdt-btn-header-bg-hover: theme('colors.gray.200');
+        --sdt-clock-bg: theme('colors.gray.200');
+        --sdt-clock-bg-minute: theme('colors.gray.200');
+        --sdt-clock-bg-shadow: none;
+        --sdt-shadow: none;
     }
 </style>

--- a/packages/shared/src/lib/core/app/interfaces/platform.interface.ts
+++ b/packages/shared/src/lib/core/app/interfaces/platform.interface.ts
@@ -4,7 +4,6 @@ import { IDeepLinkManager, INotificationManager, IPincodeManager } from './manag
 import { IAppSettings } from './app-settings.interface'
 import { IAppVersionDetails } from './app-version-details.interface'
 import { IPlatformEventMap } from './platform-event-map.interface'
-import { AppTheme } from '../enums'
 
 export interface IPlatform {
     getStrongholdBackupDestination(defaultPath: string): Promise<string | null>
@@ -53,7 +52,6 @@ export interface IPlatform {
     trackEvent(eventName: string, eventProperties?: Record<string, unknown>): void
 
     getLanguageCode(): Promise<string>
-    updateTheme(theme: AppTheme): void
 
     startLedgerProcess(): void
     killLedgerProcess(): void

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -13,6 +13,7 @@ const NODE_MODULES_ROUTES = [
 ]
 
 module.exports = {
+    darkMode: 'class',
     content: [
         ...SHARED_CONTENT_ROUTES,
         ...NODE_MODULES_ROUTES,

--- a/packages/shared/test/mocks/platform.mock.ts
+++ b/packages/shared/test/mocks/platform.mock.ts
@@ -93,7 +93,6 @@ const Platform: IPlatform = {
     getLanguageCode(): Promise<string> {
         return Promise.resolve('')
     },
-    updateTheme(): void {},
 }
 
 window['__CAPACITOR__'] = Platform

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,6 +381,19 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@csstools/postcss-is-pseudo-class@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-4.0.0.tgz#954c489cf207a7cfeaf4d96d39fac50757dc48cf"
+  integrity sha512-0I6siRcDymG3RrkNTSvHDMxTQ6mDyYE8awkcaHNgtYacd43msl+4ZWDfQ1yZQ/viczVWjqJkLmPiRHSgxn5nZA==
+  dependencies:
+    "@csstools/selector-specificity" "^3.0.0"
+    postcss-selector-parser "^6.0.13"
+
+"@csstools/selector-specificity@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
+  integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
+
 "@develar/schema-utils@~2.6.5":
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/@develar/schema-utils/-/schema-utils-2.6.5.tgz#3ece22c5838402419a6e0425f85742b961d9b6c6"
@@ -6390,6 +6403,13 @@ is-core-module@^2.11.0:
   dependencies:
     has "^1.0.3"
 
+is-core-module@^2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.13.0.tgz#bb52aa6e2cbd49a30c2ba68c42bf3435ba6072db"
+  integrity sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==
+  dependencies:
+    has "^1.0.3"
+
 is-date-object@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.5.tgz#0841d5536e724c25597bf6ea62e1bd38298df31f"
@@ -8448,7 +8468,7 @@ postcss-reporter@^7.0.0:
     picocolors "^1.0.0"
     thenby "^1.3.4"
 
-postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
+postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.13, postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
   version "6.0.13"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
   integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
@@ -8891,12 +8911,21 @@ resolve.exports@^2.0.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
   integrity sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==
 
-resolve@^1.1.7, resolve@^1.10.0, resolve@^1.20.0, resolve@^1.22.2:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.20.0:
   version "1.22.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.2.tgz#0ed0943d4e301867955766c9f3e1ae6d01c6845f"
   integrity sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==
   dependencies:
     is-core-module "^2.11.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
+resolve@^1.22.2:
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.4.tgz#1dc40df46554cdaf8948a486a10f6ba1e2026c34"
+  integrity sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==
+  dependencies:
+    is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
@@ -9889,10 +9918,10 @@ tailwind-merge@^1.13.2:
   resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.14.0.tgz#e677f55d864edc6794562c63f5001f45093cdb8b"
   integrity sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==
 
-tailwindcss@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.2.tgz#2f9e35d715fdf0bbf674d90147a0684d7054a2d3"
-  integrity sha512-9jPkMiIBXvPc2KywkraqsUfbfj+dHDb+JPWtSJa9MLFdrPyazI7q6WX2sUrm7R9eVR7qqv3Pas7EvQFzxKnI6w==
+tailwindcss@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.3.tgz#90da807393a2859189e48e9e7000e6880a736daf"
+  integrity sha512-A0KgSkef7eE4Mf+nKJ83i75TMyq8HqY3qmFIJSWy8bNt0v1lG7jUcpGpoTFxAwYcWOphcTBLPPJg+bDfhDf52w==
   dependencies:
     "@alloc/quick-lru" "^5.2.0"
     arg "^5.0.2"
@@ -9914,7 +9943,6 @@ tailwindcss@3.3.2:
     postcss-load-config "^4.0.1"
     postcss-nested "^6.0.1"
     postcss-selector-parser "^6.0.11"
-    postcss-value-parser "^4.2.0"
     resolve "^1.22.2"
     sucrase "^3.32.0"
 


### PR DESCRIPTION
## Summary

`flowbite-svelte` depends on the Tailwind dark mode class strategy, so `bloom-ui` has it, the issue is that because of it the components from `@bloomwalletio/ui` will not display dark mode if the `media` strategy is being used. This PR fixes the dark mode class strategy in `bloom` by adding a PostCSS plugin that transforms the `:is()` selector into a simple selector, enabling the correct compilation of stylesheet for dark mode (issue for compilation not working correctly is unknown yet).

`:is()` selector for dark mode was introduced in Tailwind 3.3.0.

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

### Instructions

- Toggle between light and dark mode

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
