### PR TITLE
enhancement: use balance sum across networks in `AccountSummary`

### DIFF
--- a/packages/desktop/features/wallet.features.ts
+++ b/packages/desktop/features/wallet.features.ts
@@ -12,7 +12,7 @@ const walletFeatures: IWalletFeatures = {
         },
     },
     newDashboard: {
-        enabled: false,
+        enabled: true,
     },
     walletConnect: {
         enabled: false,

--- a/packages/desktop/features/wallet.features.ts
+++ b/packages/desktop/features/wallet.features.ts
@@ -12,7 +12,7 @@ const walletFeatures: IWalletFeatures = {
         },
     },
     newDashboard: {
-        enabled: true,
+        enabled: false,
     },
     walletConnect: {
         enabled: false,

--- a/packages/desktop/views/dashboard/new-dashboard/panes/account-summary/AccountSummaryPane.svelte
+++ b/packages/desktop/views/dashboard/new-dashboard/panes/account-summary/AccountSummaryPane.svelte
@@ -6,13 +6,14 @@
 
     export let account: IAccountState
 
+    const stardustNetworkId = getActiveNetworkId()
     const evmChainNetworkId = $network.getChains()[0].getConfiguration().id
 </script>
 
 <Pane classes="w-full flex flex-row shrink-0 justify-between items-center border border-solid border-gray-100">
-    <AccountSummary {account} />
+    <AccountSummary {account} {stardustNetworkId} {evmChainNetworkId} />
     <div class="middle w-full">
-        <AccountStardustNetworkSummary {account} networkId={getActiveNetworkId()} />
+        <AccountStardustNetworkSummary {account} networkId={stardustNetworkId} />
     </div>
     <AccountEvmChainSummary {account} networkId={evmChainNetworkId} />
 </Pane>

--- a/packages/desktop/views/dashboard/new-dashboard/panes/account-summary/components/AccountEvmChainSummary.svelte
+++ b/packages/desktop/views/dashboard/new-dashboard/panes/account-summary/components/AccountEvmChainSummary.svelte
@@ -18,7 +18,7 @@
     function buildAccountEvmChainSummaryProps(): IAccountNetworkSummaryProps {
         const chain = getNetwork().getChain(networkId)
         const networkTokens = $selectedAccountTokens?.[networkId]
-        const evmChainBaseToken: ITokenWithBalance = $selectedAccountTokens?.[getNetwork().getMetadata().id]?.baseCoin
+        const evmChainBaseToken: ITokenWithBalance = $selectedAccountTokens?.[networkId]?.baseCoin
         const networkTokenBalance = formatTokenAmountBestMatch(
             evmChainBaseToken?.balance.total ?? 0,
             evmChainBaseToken?.metadata

--- a/packages/desktop/views/dashboard/new-dashboard/panes/account-summary/components/AccountEvmChainSummary.svelte
+++ b/packages/desktop/views/dashboard/new-dashboard/panes/account-summary/components/AccountEvmChainSummary.svelte
@@ -18,7 +18,7 @@
     function buildAccountEvmChainSummaryProps(): IAccountNetworkSummaryProps {
         const chain = getNetwork().getChain(networkId)
         const networkTokens = $selectedAccountTokens?.[networkId]
-        const evmChainBaseToken: ITokenWithBalance = $selectedAccountTokens?.[networkId]?.baseCoin
+        const evmChainBaseToken: ITokenWithBalance = networkTokens?.baseCoin
         const networkTokenBalance = formatTokenAmountBestMatch(
             evmChainBaseToken?.balance.total ?? 0,
             evmChainBaseToken?.metadata

--- a/packages/desktop/views/dashboard/new-dashboard/panes/account-summary/components/AccountSummary.svelte
+++ b/packages/desktop/views/dashboard/new-dashboard/panes/account-summary/components/AccountSummary.svelte
@@ -2,26 +2,33 @@
     import { Button, IconName, Text } from '@bloomwalletio/ui'
     import { AccountActionsMenu } from '@components'
     import { IAccountState } from '@core/account'
-    import { formatCurrency } from '@core/i18n'
+    import { formatCurrency, getDecimalSeparator } from '@core/i18n'
     import { resetLedgerPreparedOutput, resetShowInternalVerificationPopup } from '@core/ledger'
     import { getMarketAmountFromTokenValue } from '@core/market/actions'
-    import { getActiveNetworkId } from '@core/network'
+    import { NetworkId } from '@core/network'
     import { ITokenWithBalance } from '@core/token'
     import { selectedAccountTokens } from '@core/token/stores'
     import { resetSendFlowParameters } from '@core/wallet'
     import { PopupId, openPopup } from '@desktop/auxiliary/popup'
     import { SendFlowRouter, sendFlowRouter } from '@views'
+    import { activeProfile } from '@core/profile/stores'
 
     export let account: IAccountState
+    export let stardustNetworkId: NetworkId
+    export let evmChainNetworkId: NetworkId
 
     let formattedBalance: [string, string]
     $: $selectedAccountTokens, (formattedBalance = getFormattedBalance())
 
     function getFormattedBalance(): [string, string] {
-        const baseCoin: ITokenWithBalance = $selectedAccountTokens?.[getActiveNetworkId()]?.baseCoin
-        const formattedCurrency = formatCurrency(getMarketAmountFromTokenValue(baseCoin.balance.available, baseCoin))
-        const length = formattedCurrency.length
-        return [formattedCurrency.slice(0, length - 3), formattedCurrency.slice(length - 3, length)]
+        const stardustBaseToken: ITokenWithBalance = $selectedAccountTokens?.[stardustNetworkId]?.baseCoin
+        const evmChainBaseToken: ITokenWithBalance = $selectedAccountTokens?.[evmChainNetworkId]?.baseCoin
+        const availableBalance =
+            (stardustBaseToken?.balance?.available ?? 0) + (evmChainBaseToken?.balance?.available ?? 0)
+        const formattedCurrency = formatCurrency(getMarketAmountFromTokenValue(availableBalance, stardustBaseToken))
+        const decimalSeparator = getDecimalSeparator($activeProfile?.settings?.marketCurrency)
+        const [integer, decimals] = formattedCurrency.split(decimalSeparator)
+        return [integer, decimalSeparator + decimals]
     }
 
     function onSendClick(): void {


### PR DESCRIPTION
## Summary

> Please summarize your changes, describing **what** they are and **why** they were made.

This PR makes it so that the total balance displayed in fiat is summed from both the Stardust and EVM chain networks.

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [x] Linux
    -   [ ] Windows

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
