### PR TITLE
chore: update about and error windows

### DIFF
--- a/packages/desktop/lib/electron/preloads/about.preload.ts
+++ b/packages/desktop/lib/electron/preloads/about.preload.ts
@@ -12,12 +12,11 @@ interface AboutData {
 contextBridge.exposeInMainWorld('about', {
     getData: async (): Promise<AboutData> => {
         const data = await ipcRenderer.invoke('menu-data')
-        const stage = process.env.STAGE
 
         const aboutData: AboutData = {
             appName: productName,
             version: data.strings.version.replace('{version}', version),
-            iconPath: `./assets/logos/darkmode/${stage}_firefly_logo.svg`,
+            iconPath: './assets/logos/lightmode/bloom_logo.svg',
         }
 
         return aboutData

--- a/packages/desktop/lib/electron/preloads/about.preload.ts
+++ b/packages/desktop/lib/electron/preloads/about.preload.ts
@@ -16,7 +16,7 @@ contextBridge.exposeInMainWorld('about', {
         const aboutData: AboutData = {
             appName: productName,
             version: data.strings.version.replace('{version}', version),
-            iconPath: './assets/logos/lightmode/bloom_logo.svg',
+            iconPath: './assets/logos/darkmode/bloom_logo.svg',
         }
 
         return aboutData

--- a/packages/desktop/lib/electron/preloads/error.preload.ts
+++ b/packages/desktop/lib/electron/preloads/error.preload.ts
@@ -21,7 +21,7 @@ contextBridge.exposeInMainWorld('error', {
         const data = await ipcRenderer.invoke('error-data')
 
         const errorData: ErrorData = {
-            iconPath: './assets/logos/lightmode/bloom_logo.svg',
+            iconPath: './assets/logos/darkmode/bloom_logo.svg',
             version,
             diagnostics: data.diagnostics
                 .map((d: DiagnosticData) => `${d.label.replace('popups.diagnostics.', '')}: ${d.value}`)

--- a/packages/desktop/lib/electron/preloads/error.preload.ts
+++ b/packages/desktop/lib/electron/preloads/error.preload.ts
@@ -20,9 +20,8 @@ contextBridge.exposeInMainWorld('error', {
     getData: async (): Promise<ErrorData> => {
         const data = await ipcRenderer.invoke('error-data')
 
-        const stage = process.env.STAGE
         const errorData: ErrorData = {
-            iconPath: `./assets/logos/darkmode/${stage}_firefly_logo.svg`,
+            iconPath: './assets/logos/lightmode/bloom_logo.svg',
             version,
             diagnostics: data.diagnostics
                 .map((d: DiagnosticData) => `${d.label.replace('popups.diagnostics.', '')}: ${d.value}`)

--- a/packages/desktop/public/error.html
+++ b/packages/desktop/public/error.html
@@ -117,7 +117,7 @@
          alt="App icon"
          height="70"
          width="70" />
-    <h2>Unfortunately an error has occurred in Firefly.</h2>
+    <h2>Unfortunately an error has occurred in Bloom.</h2>
     <hr />
     <p id="version"></p>
     <pre id="diagnostics"></pre>
@@ -128,8 +128,8 @@
     <footer>
       <p class="help">
         Please visit <a href="#"
-           onclick="javascript:window.error.openUrl('https://discord.iota.org')">https://discord.iota.org</a> to get
-        help from the IOTA community.
+           onclick="javascript:window.error.openUrl('https://discord.bloomwallet.io')">https://discord.bloomwallet.io</a> to get
+        help from the Bloom community.
       </p>
       <p class="help">
         Alternatively report this problem at <a href="#"

--- a/packages/desktop/public/error.html
+++ b/packages/desktop/public/error.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport"
         content="width=device-width, initial-scale=1, user-scalable=no" />
-  <title>Firefly Error</title>
+  <title>Bloom Error</title>
   <style>
     @font-face {
       font-family: 'Silka';

--- a/packages/desktop/public/error.html
+++ b/packages/desktop/public/error.html
@@ -128,7 +128,7 @@
     <footer>
       <p class="help">
         Please visit <a href="#"
-           onclick="javascript:window.error.openUrl('https://discord.bloomwallet.io')">https://discord.bloomwallet.io</a> to get
+           onclick="javascript:window.error.openUrl('https://bloomwallet.io')">https://bloomwallet.io</a> to get
         help from the Bloom community.
       </p>
       <p class="help">


### PR DESCRIPTION
## Summary

Loading screen and splash screen had replaced logos, so we also need to replace content in error and about windows as well

## Testing

### Platforms
-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

### Instructions

- Error window is just opened when the app is packaged, but to easily open the about and error windows at the same time, do the following:
    - Open `main.process.ts`
    - Change condition in line 72 from `app.isPackaged` to `!app.isPackaged`
    - Create a new line after line 485 with `handleError('[Main Context] Unhandled Error', new Error('Test Error'))`
    - Then whenever you open the about window it will also open the error window.
- Open about window.
- Check about window, if the Bloom logo, strings and links are there it is correct.
- Check error window, if the Bloom logo, strings and links are there it is correct.


## Checklist
-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
