### PR TITLE
feat: adds Bloom confirmation dialog

### DIFF
--- a/packages/desktop/components/ConfirmationDialog.svelte
+++ b/packages/desktop/components/ConfirmationDialog.svelte
@@ -28,8 +28,8 @@
 </script>
 
 {#if visible}
-    <overlay in:fade={{ duration: 100 }} out:fade={{ duration: 50 }}>
-        <dialog-container>
+    <overlay in:fade={{ duration: 100 }}>
+        <dialog-container class="popup">
             <PopupTemplate
                 {title}
                 {description}
@@ -57,11 +57,6 @@
     }
 
     dialog-container {
-        @apply p-8;
-        @apply bg-surface dark:bg-surface-dark;
-        @apply border border-solid border-stroke dark:border-stroke-dark;
-        @apply shadow-elevation-4;
         @apply max-w-[25rem];
-        border-radius: 32px;
     }
 </style>

--- a/packages/desktop/components/ConfirmationDialog.svelte
+++ b/packages/desktop/components/ConfirmationDialog.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+    import { fade } from 'svelte/transition'
+    import { Alert } from '@bloomwalletio/ui'
+    import { localize } from '@core/i18n'
+    import { PopupTemplate } from './popup'
+
+    export let visible: boolean = false
+    export let variant: 'primary' | 'success' | 'warning' | 'danger' | 'info' = 'primary'
+    export let title: string
+    export let description: string = ''
+    export let alert: { variant?: 'success' | 'warning' | 'danger' | 'info'; text: string } | undefined = undefined
+    export let backText: string = localize('actions.cancel')
+    export let confirmText: string = localize('actions.confirm')
+    export let onConfirm: () => void
+
+    export function openDialog(): void {
+        visible = true
+    }
+
+    function closeDialog(): void {
+        visible = false
+    }
+
+    function onConfirmClick(): void {
+        onConfirm()
+        closeDialog()
+    }
+</script>
+
+{#if visible}
+    <overlay in:fade={{ duration: 100 }} out:fade={{ duration: 50 }}>
+        <dialog-container>
+            <PopupTemplate
+                {title}
+                {description}
+                backButton={{
+                    text: backText,
+                    onClick: closeDialog,
+                }}
+                continueButton={{
+                    color: variant,
+                    text: confirmText,
+                    onClick: onConfirmClick,
+                }}
+            >
+                {#if alert}
+                    <Alert {...alert} />
+                {/if}
+            </PopupTemplate>
+        </dialog-container>
+    </overlay>
+{/if}
+
+<style lang="postcss">
+    overlay {
+        @apply inset-0 fixed z-40 flex items-center justify-center bg-neutral-6/75;
+    }
+
+    dialog-container {
+        @apply p-8;
+        @apply bg-surface dark:bg-surface-dark;
+        @apply border border-solid border-stroke dark:border-stroke-dark;
+        @apply shadow-elevation-4;
+        @apply max-w-[25rem];
+        border-radius: 32px;
+    }
+</style>

--- a/packages/desktop/components/index.ts
+++ b/packages/desktop/components/index.ts
@@ -6,6 +6,7 @@ export * from './panes'
 export * from './popup'
 
 export { default as AccountSwitcher } from './AccountSwitcher.svelte'
+export { default as ConfirmationDialog } from './ConfirmationDialog.svelte'
 export { default as ContactAddressCard } from './ContactAddressCard.svelte'
 export { default as ContactCard } from './ContactCard.svelte'
 export { default as ContactMetadataTable } from './ContactMetadataTable.svelte'

--- a/packages/desktop/components/popup/Popup.svelte
+++ b/packages/desktop/components/popup/Popup.svelte
@@ -136,7 +136,6 @@
             if ('function' === typeof props?.onCancelled) {
                 props?.onCancelled()
             }
-            modifyPopupState({ confirmClickOutside: false })
             closePopup()
         }
     }

--- a/packages/desktop/components/popup/Popup.svelte
+++ b/packages/desktop/components/popup/Popup.svelte
@@ -3,8 +3,11 @@
     import { fade } from 'svelte/transition'
     import { CloseButton } from '@bloomwalletio/ui'
     import { closePopup, PopupComponentMap, PopupId } from '@desktop/auxiliary/popup'
+    import { modifyPopupState } from '@desktop/auxiliary/popup/helpers'
+
     import { IS_WINDOWS } from '@core/app/constants'
     import { clickOutside } from '@core/utils/ui'
+    import ConfirmationDialog from '../ConfirmationDialog.svelte'
 
     // Popups
     import AccountSwitcherPopup from './popups/AccountSwitcherPopup.svelte'
@@ -48,7 +51,6 @@
     import VerifyLedgerTransactionPopup from './popups/VerifyLedgerTransactionPopup.svelte'
     import VoteForProposal from './popups/VoteForProposalPopup.svelte'
     import VotingPowerToZeroPopup from './popups/VotingPowerToZeroPopup.svelte'
-    import { modifyPopupState } from '@desktop/auxiliary/popup/helpers'
     import { localize } from '@core/i18n'
 
     export let id: PopupId
@@ -77,6 +79,7 @@
     }
 
     let popupContent
+    let confirmationDialog: ConfirmationDialog
 
     const POPUP_MAP: PopupComponentMap = {
         [PopupId.AccountSwitcher]: AccountSwitcherPopup,
@@ -144,11 +147,7 @@
                 props?.onCancelled()
             }
             if (confirmClickOutside) {
-                const confirm = window.confirm(localize('warning.closePopup'))
-                if (confirm) {
-                    modifyPopupState({ confirmClickOutside: false })
-                    closePopup()
-                }
+                confirmationDialog?.openDialog()
             } else {
                 closePopup()
             }
@@ -211,6 +210,19 @@
     </popup>
     <button type="button" tabindex="0" on:focus={onFocusLast} />
 </overlay>
+{#if confirmClickOutside}
+    <ConfirmationDialog
+        bind:this={confirmationDialog}
+        onConfirm={() => {
+            modifyPopupState({ confirmClickOutside: false })
+            closePopup()
+        }}
+        confirmText={localize('actions.close')}
+        title="Close popup"
+        variant="danger"
+        alert={{ variant: 'danger', text: localize('warning.closePopup') }}
+    />
+{/if}
 
 <style lang="postcss">
     popup {

--- a/packages/desktop/components/popup/Popup.svelte
+++ b/packages/desktop/components/popup/Popup.svelte
@@ -201,7 +201,7 @@
         on:clickOutside={tryClosePopupOnClickOutside}
         bind:this={popupContent}
         class:relative
-        class={size}
+        class="popup {size}"
     >
         <svelte:component this={POPUP_MAP[id]} {...props} />
         {#if !hideClose}
@@ -225,18 +225,18 @@
 {/if}
 
 <style lang="postcss">
-    popup {
+    :global(.popup) {
         @apply w-full p-8;
         @apply bg-surface dark:bg-surface-dark;
         @apply border border-solid border-stroke dark:border-stroke-dark;
         @apply shadow-elevation-4;
         border-radius: 32px;
+    }
 
-        &.medium {
-            max-width: 480px;
-        }
-        &.large {
-            max-width: 630px;
-        }
+    .medium {
+        max-width: 480px;
+    }
+    .large {
+        max-width: 630px;
     }
 </style>

--- a/packages/desktop/lib/auxiliary/popup/actions/openPopup.ts
+++ b/packages/desktop/lib/auxiliary/popup/actions/openPopup.ts
@@ -10,6 +10,7 @@ export function openPopup(
         preventClose = false,
         transition = undefined,
         overflow = false,
+        confirmClickOutside = false,
         relative = true,
     }: Omit<IPopupState, 'active'>,
     forceClose: boolean = false,
@@ -20,5 +21,8 @@ export function openPopup(
             return
         }
     }
-    modifyPopupState({ active: true, id, hideClose, preventClose, transition, props, overflow, relative }, forceClose)
+    modifyPopupState(
+        { active: true, id, hideClose, preventClose, confirmClickOutside, transition, props, overflow, relative },
+        forceClose
+    )
 }

--- a/packages/desktop/views/dashboard/developer/components/MintNativeTokenButton.svelte
+++ b/packages/desktop/views/dashboard/developer/components/MintNativeTokenButton.svelte
@@ -13,6 +13,7 @@
         if (hasAliases) {
             openPopup({
                 id: PopupId.MintNativeTokenForm,
+                confirmClickOutside: true,
             })
         } else {
             openPopup({

--- a/packages/desktop/views/dashboard/developer/components/MintNftButton.svelte
+++ b/packages/desktop/views/dashboard/developer/components/MintNftButton.svelte
@@ -9,6 +9,7 @@
         resetMintNftDetails()
         openPopup({
             id: PopupId.MintNftForm,
+            confirmClickOutside: true,
         })
     }
 </script>


### PR DESCRIPTION
## Summary

Adds a Bloom dialog, since `window.confirm` only looked good on macOS. Additionally, it broke the linux version of the app rendering it unable to click cancel/ok.

...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
