### PR TITLE
ci: enable signed build for Windows

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -54,13 +54,13 @@ jobs:
         needs: [setup]
         strategy:
             matrix:
-                os: [ubuntu-20.04, windows-2019, macos-11]
+                os: [ubuntu-20.04, windows-2022, macos-11]
             fail-fast: true
         with:
             os: ${{ matrix.os }}
             version: ${{ needs.setup.outputs.version }}
             stage: ${{ inputs.stage || needs.setup.outputs.stage }}
-            sign: ${{ matrix.os != 'windows-2019' }}
+            sign: ${{ matrix.os != 'windows-2022' }}
             upload: true
         secrets: inherit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
         options:
           - macos-11
           - ubuntu-20.04
-          - windows-2019
+          - windows-2022
       stage:
         description: 'Stage'
         required: true

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -51,15 +51,48 @@ jobs:
 
             - name: Install LLVM and Clang (Windows) # required for bindgen to work, see https://github.com/rust-lang/rust-bindgen/issues/1797
               uses: KyleMayes/install-llvm-action@32c4866ebb71e0949e8833eb49beeebed48532bd
-              if: inputs.os == 'windows-2019'
+              if: inputs.os == 'windows-2022'
               with:
                   version: '11.0'
                   directory: ${{ runner.temp }}/llvm
 
             - name: Set LIBCLANG_PATH (Windows)
               run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-              if: inputs.os == 'windows-2019'
+              if: inputs.os == 'windows-2022'
 
+            - name: Set up certificate (Windows)
+              if: ${{ inputs.sign && inputs.os == 'windows-2022' }}
+              run: |
+                echo "${{ secrets.SM_CLIENT_CERT_FILE_B64 }}" | base64 --decode > /d/Certificate_pkcs12.p12
+              shell: bash 
+
+            - name: Set variables for signing (Windows)
+              if: ${{ inputs.sign && inputs.os == 'windows-2022' }}
+              run: |
+                echo "SM_HOST=${{ secrets.SM_HOST }}" >> "$GITHUB_ENV"
+                echo "SM_API_KEY=${{ secrets.SM_API_KEY }}" >> "$GITHUB_ENV"
+                echo "SM_CLIENT_CERT_FILE=D:\\Certificate_pkcs12.p12" >> "$GITHUB_ENV"
+                echo "SM_CLIENT_CERT_PASSWORD=${{ secrets.SM_CLIENT_CERT_PASSWORD }}" >> "$GITHUB_ENV"
+                echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
+                echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
+                echo "C:\Program Files\DigiCert\DigiCert Keylocker Tools" >> $GITHUB_PATH
+              shell: bash
+
+            - name: Install DigiCert KeyLocker KSP (Windows)
+              if: ${{ inputs.sign && inputs.os == 'windows-2022' }}
+              run: |
+                curl -X GET  "https://one.digicert.com/signingmanager/api-ui/v1/releases/Keylockertools-windows-x64.msi/download" -H "x-api-key:${{ secrets.SM_API_KEY }}" -o Keylockertools-windows-x64.msi
+                msiexec /i Keylockertools-windows-x64.msi /quiet /qn
+                smksp_registrar.exe list
+                smctl.exe keypair ls
+                C:\\Windows\\System32\\certutil.exe -csp "DigiCert Signing Manager KSP" -key -user
+              shell: cmd
+
+            - name: Sync Certificates with KeyLocker KSP (Windows)
+              if: ${{ inputs.sign && inputs.os == 'windows-2022' }}
+              run: smctl windows certsync
+              shell: cmd
+            
             - name: Set deployment target (MacOS)
               run: echo "MACOSX_DEPLOYMENT_TARGET=10.14" >> $GITHUB_ENV # TODO: set this to 10.12 once rocksDB issue is fixed
               if: inputs.os == 'macos-11'
@@ -78,11 +111,11 @@ jobs:
 
             - name: Enable verbose output for electron-builder (macOS/Linux)
               run: echo "DEBUG=electron-builder" >> $GITHUB_ENV
-              if: inputs.os != 'windows-2019'
+              if: inputs.os != 'windows-2022'
 
             - name: Enable verbose output for electron-builder (Windows)
               run: echo "DEBUG=electron-builder" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-              if: inputs.os == 'windows-2019'
+              if: inputs.os == 'windows-2022'
 
             - name: Set up .npmrc file to use GitHub Packages
               run: |
@@ -130,12 +163,11 @@ jobs:
             - name: Build signed Electron app (Windows)
               run: yarn compile:${env:STAGE}:win
               env:
-                  CSC_LINK: ${{ secrets.WIN_CERT_BASE64 }}
-                  CSC_KEY_PASSWORD: ${{ secrets.WIN_CERT_PASSWORD }}
+                  CERTIFICATE_FINGERPRINT: ${{ secrets.SM_CODE_SIGNING_CERT_SHA1_HASH }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PRIVATE_REPO_ACCESS_TOKEN: ${{ vars.PRIVATE_REPO_ACCESS_TOKEN }} # TODO: Remove following lines after we're open source
               working-directory: packages/desktop
-              if: ${{ inputs.sign && inputs.os == 'windows-2019' }}
+              if: ${{ inputs.sign && inputs.os == 'windows-2022' }}
 
             - name: Build unsigned Electron app (Windows)
               run: yarn compile:${env:STAGE}:win
@@ -143,7 +175,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PRIVATE_REPO_ACCESS_TOKEN: ${{ vars.PRIVATE_REPO_ACCESS_TOKEN }} # TODO: Remove following lines after we're open source
               working-directory: packages/desktop
-              if: ${{ ! inputs.sign && inputs.os == 'windows-2019' }}
+              if: ${{ ! inputs.sign && inputs.os == 'windows-2022' }}
 
             - name: Build Electron app (Linux)
               run: yarn compile:${STAGE}:linux
@@ -181,7 +213,7 @@ jobs:
             - name: Compute checksums (Windows)
               run: Get-ChildItem "." -Filter bloom-desktop-* | Foreach-Object { $(Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash | Set-Content ($_.FullName + '.sha256') }
               working-directory: packages/desktop/out
-              if: inputs.os == 'windows-2019'
+              if: inputs.os == 'windows-2022'
 
             - name: Upload artifacts
               if: inputs.upload

--- a/.github/workflows/reusable_release.yml
+++ b/.github/workflows/reusable_release.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Downloading artifacts
               uses: actions/download-artifact@v2
               with:
-                  name: bloom-desktop-windows-2019
+                  name: bloom-desktop-windows-2022
                   path: assets
 
             - name: Downloading artifacts

--- a/packages/desktop/customSign.js
+++ b/packages/desktop/customSign.js
@@ -1,0 +1,9 @@
+'use strict'
+
+exports.default = async function (configuration) {
+    if (configuration.path) {
+        require('child_process').execSync(
+            `smctl sign --fingerprint=${process.env.CERTIFICATE_FINGERPRINT} --input "${String(configuration.path)}"`
+        )
+    }
+}

--- a/packages/desktop/electron-builder-config.ts
+++ b/packages/desktop/electron-builder-config.ts
@@ -103,6 +103,7 @@ const prodConfig: Configuration = {
         target: 'nsis',
         timeStampServer: 'http://timestamp.sectigo.com',
         rfc3161TimeStampServer: 'http://timestamp.sectigo.com',
+        sign: './customSign.js',
     },
     linux: {
         target: ['AppImage'],


### PR DESCRIPTION
## Summary

closes #481 

This PR enables the signing for Windows in our build workflow, using the EV certificate from Digicert KeyLocker.

It also updates the GitHub Runner OS from windows-2019 to windows-2022

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
