### PR TITLE
fix: filter modal height after re-open

### DIFF
--- a/packages/shared/src/components/modals/Modal.svelte
+++ b/packages/shared/src/components/modals/Modal.svelte
@@ -81,22 +81,23 @@
     $: if (show && autoMaxHeight) updateMaxHeight()
 </script>
 
-<modal-content
-    bind:this={modal}
-    in:fade={{ duration: 100 }}
-    use:clickOutside
-    on:clickOutside={onClickOutside}
-    class="{size} {classes}"
-    class:hidden={!show}
-    style:max-height={maxHeight ? `${maxHeight}px` : undefined}
-    style:top
-    style:right
-    style:bottom
-    style:left
-    style:position={fixed ? 'fixed' : absolute ? 'absolute' : 'relative'}
->
-    <slot />
-</modal-content>
+{#if show}
+    <modal-content
+        bind:this={modal}
+        in:fade={{ duration: 100 }}
+        use:clickOutside
+        on:clickOutside={onClickOutside}
+        class="{size} {classes}"
+        style:max-height={maxHeight ? `${maxHeight}px` : undefined}
+        style:top
+        style:right
+        style:bottom
+        style:left
+        style:position={fixed ? 'fixed' : absolute ? 'absolute' : 'relative'}
+    >
+        <slot />
+    </modal-content>
+{/if}
 
 <style lang="postcss">
     modal-content {

--- a/packages/shared/src/components/modals/Modal.svelte
+++ b/packages/shared/src/components/modals/Modal.svelte
@@ -62,20 +62,24 @@
         maxHeight = maxSpace - 10
     }
 
+    function handleResize() {
+        updateMaxHeight()
+    }
+
     onMount(() => {
         if (autoMaxHeight) {
-            window.addEventListener('resize', () => void updateMaxHeight())
-            void updateMaxHeight()
+            window.addEventListener('resize', handleResize)
+            updateMaxHeight()
         }
     })
 
     onDestroy(() => {
         if (autoMaxHeight) {
-            window.removeEventListener('resize', () => void updateMaxHeight())
+            window.removeEventListener('resize', handleResize)
         }
     })
 
-    $: show, autoMaxHeight && void updateMaxHeight()
+    $: if (show && autoMaxHeight) updateMaxHeight()
 </script>
 
 {#if show}

--- a/packages/shared/src/components/modals/Modal.svelte
+++ b/packages/shared/src/components/modals/Modal.svelte
@@ -53,13 +53,12 @@
         if (!show || !modal) {
             return
         }
+
         const viewportHeight = window.innerHeight
-        const modalRect = modal?.getBoundingClientRect()
-        const spaceAbove = modalRect?.top
-        const spaceBelow = viewportHeight - modalRect?.bottom
-        const maxSpace =
-            spaceBelow > 0 ? modalRect?.height - Math.abs(spaceAbove) : modalRect?.height - Math.abs(spaceBelow)
-        maxHeight = maxSpace - 10
+        const modalRect = modal.getBoundingClientRect()
+
+        const availableSpace = position.top ? viewportHeight - modalRect.top : modalRect.bottom
+        maxHeight = availableSpace - 10
     }
 
     function handleResize() {
@@ -82,23 +81,22 @@
     $: if (show && autoMaxHeight) updateMaxHeight()
 </script>
 
-{#if show}
-    <modal-content
-        bind:this={modal}
-        in:fade={{ duration: 100 }}
-        use:clickOutside
-        on:clickOutside={onClickOutside}
-        class="{size} {classes}"
-        style:max-height={maxHeight ? `${maxHeight}px` : undefined}
-        style:top
-        style:right
-        style:bottom
-        style:left
-        style:position={fixed ? 'fixed' : absolute ? 'absolute' : 'relative'}
-    >
-        <slot />
-    </modal-content>
-{/if}
+<modal-content
+    bind:this={modal}
+    in:fade={{ duration: 100 }}
+    use:clickOutside
+    on:clickOutside={onClickOutside}
+    class="{size} {classes}"
+    class:hidden={!show}
+    style:max-height={maxHeight ? `${maxHeight}px` : undefined}
+    style:top
+    style:right
+    style:bottom
+    style:left
+    style:position={fixed ? 'fixed' : absolute ? 'absolute' : 'relative'}
+>
+    <slot />
+</modal-content>
 
 <style lang="postcss">
     modal-content {


### PR DESCRIPTION
## Summary

closes #1364 

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

### Instructions

- Open and re-open filter modal

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
