### PR TITLE
feat: follow MM convention for using address indices to generate multiple accounts

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "productName": "Bloom",
-    "version": "0.1.0-alpha-7",
+    "version": "0.1.0",
     "description": "Simple and secure web3 wallet for the IOTA and Shimmer ecosystem",
     "main": "public/build/main.process.js",
     "repository": "git@github.com:bloomwalletio/bloom.git",

--- a/packages/desktop/views/dashboard/send-flow/views/SelectTokenView.svelte
+++ b/packages/desktop/views/dashboard/send-flow/views/SelectTokenView.svelte
@@ -29,20 +29,16 @@
     $: accountTokens, searchValue, selectedTab, setFilteredTokenList()
 
     let tokenError: string = ''
-    $: if (isEvmChain(selectedToken?.networkId)) {
-        if (!canAccountMakeEvmTransaction($selectedAccountIndex, selectedToken.networkId, $sendFlowParameters?.type)) {
-            tokenError = localize('error.send.insufficientFundsTransaction')
-        }
-    } else if (isStardustNetwork(selectedToken?.networkId)) {
-        if (
-            !canAccountMakeStardustTransaction(
-                $selectedAccountIndex,
-                selectedToken.networkId,
-                $sendFlowParameters?.type
-            )
-        ) {
-            tokenError = localize('error.send.insufficientFundsTransaction')
-        }
+    $: if (
+        isEvmChain(selectedToken?.networkId) &&
+        !canAccountMakeEvmTransaction($selectedAccountIndex, selectedToken.networkId, $sendFlowParameters?.type)
+    ) {
+        tokenError = localize('error.send.insufficientFundsTransaction')
+    } else if (
+        isStardustNetwork(selectedToken?.networkId) &&
+        !canAccountMakeStardustTransaction($selectedAccountIndex, selectedToken.networkId, $sendFlowParameters?.type)
+    ) {
+        tokenError = localize('error.send.insufficientFundsTransaction')
     } else {
         tokenError = ''
     }

--- a/packages/shared/src/lib/core/layer-2/actions/generateAndStoreEvmAddressForAccounts.ts
+++ b/packages/shared/src/lib/core/layer-2/actions/generateAndStoreEvmAddressForAccounts.ts
@@ -20,15 +20,19 @@ export async function generateAndStoreEvmAddressForAccounts(
         let evmAddress: string | undefined
         if (profileType === ProfileType.Software) {
             const manager = await api.getSecretManager(getProfileManager().id)
-            evmAddress = (
-                await manager.generateEvmAddresses({
-                    coinType,
-                    accountIndex,
-                    options: {
-                        internal: false,
-                    },
-                })
-            )?.[0]
+            // Follow MetaMask's convention around incrementing address indices instead of account indices
+            const addresses = await manager.generateEvmAddresses({
+                coinType,
+                accountIndex: 0,
+                range: {
+                    start: accountIndex,
+                    end: accountIndex + 1,
+                },
+                options: {
+                    internal: false,
+                },
+            })
+            evmAddress = addresses?.[0]
         } else {
             evmAddress = await Ledger.generateEvmAddress(accountIndex, coinType)
             evmAddress = evmAddress.toLowerCase()

--- a/packages/shared/src/lib/core/wallet/actions/send/signAndSendEvmTransaction.ts
+++ b/packages/shared/src/lib/core/wallet/actions/send/signAndSendEvmTransaction.ts
@@ -28,14 +28,19 @@ export async function signAndSendEvmTransaction(
 
         const bip44Path = {
             coinType,
-            account: account.index,
+            account: 0,
             change: 0,
             addressIndex: 0,
         }
+        const { index } = account
+
         let signedTransaction: string | undefined
         if (get(isSoftwareProfile)) {
+            // Follow MetaMask's convention around incrementing address indices instead of account indices
+            bip44Path.addressIndex = index
             signedTransaction = await signEvmTransactionWithStronghold(transaction, bip44Path, chainId)
         } else if (get(isActiveLedgerProfile)) {
+            bip44Path.account = index
             signedTransaction = (await Ledger.signEvmTransaction(txData, chainId, bip44Path)) as string
         }
 

--- a/packages/shared/src/lib/core/wallet/actions/signMessage.ts
+++ b/packages/shared/src/lib/core/wallet/actions/signMessage.ts
@@ -12,15 +12,18 @@ export async function signMessage(
 ): Promise<string | undefined> {
     const bip44Path = {
         coinType,
-        account: account.index,
+        account: 0,
         change: 0,
         addressIndex: 0,
     }
-
+    const { index } = account
     let signedMessage: string | undefined
     if (get(isSoftwareProfile)) {
+        // Follow MetaMask's convention around incrementing address indices instead of account indices
+        bip44Path.addressIndex = index
         signedMessage = await signMessageWithStronghold(message, bip44Path)
     } else if (get(isActiveLedgerProfile)) {
+        bip44Path.account = index
         signedMessage = await Ledger.signMessage(message, bip44Path)
     }
 


### PR DESCRIPTION
## Summary

Use MetaMask's convention of incrementing address indices instead of account indices in the BIP-44 path for Software based profiles.
...

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
