### PR TITLE
fix: windows focus

### DIFF
--- a/packages/desktop/lib/electron/processes/main.process.ts
+++ b/packages/desktop/lib/electron/processes/main.process.ts
@@ -418,7 +418,9 @@ ipcMain.handle('focus-window', () => {
         if (windows.main.isMinimized()) {
             windows.main.restore()
         }
-        windows.main.focus()
+        windows.main.show()
+        windows.main.setAlwaysOnTop(true)
+        windows.main.setAlwaysOnTop(false)
     }
 })
 

--- a/packages/shared/src/lib/auxiliary/wallet-connect/handlers/eth_transaction.handler.ts
+++ b/packages/shared/src/lib/auxiliary/wallet-connect/handlers/eth_transaction.handler.ts
@@ -6,6 +6,7 @@ import { buildEvmTransactionData } from '@core/layer-2/actions'
 import { EvmTransactionData } from '@core/layer-2'
 import { switchToRequiredAccount } from '@auxiliary/wallet-connect/utils'
 import { getSdkError } from '@walletconnect/utils'
+import { Platform } from '@core/app'
 
 export async function handleEthTransaction(
     evmTransactionData: EvmTransactionData & { from: string },
@@ -37,6 +38,8 @@ export async function handleEthTransaction(
         evmTransactionData.gasPrice = gasPrice
         evmTransactionData.gasLimit = gasLimit
     }
+
+    Platform.focusWindow()
 
     try {
         await switchToRequiredAccount(from, chain)

--- a/packages/shared/src/lib/auxiliary/wallet-connect/handlers/onSessionRequest.handler.ts
+++ b/packages/shared/src/lib/auxiliary/wallet-connect/handlers/onSessionRequest.handler.ts
@@ -6,13 +6,10 @@ import { Web3WalletTypes } from '@walletconnect/web3wallet'
 import { getConnectedDappByOrigin, getWalletClient } from '../stores'
 import { NetworkId, getNetwork } from '@core/network'
 import { CallbackParameters } from '../types'
-import { Platform } from '@core/app'
 import { getSdkError } from '@walletconnect/utils'
 import { closePopup } from '../../../../../../desktop/lib/auxiliary/popup'
 
 export function onSessionRequest(event: Web3WalletTypes.SessionRequest): void {
-    Platform.focusWindow()
-
     const { topic, params, id, verifyContext } = event
     const { request, chainId } = params
     const method = request.method

--- a/packages/shared/src/lib/auxiliary/wallet-connect/handlers/sign_message.handler.ts
+++ b/packages/shared/src/lib/auxiliary/wallet-connect/handlers/sign_message.handler.ts
@@ -5,6 +5,7 @@ import { IChain } from '@core/network'
 import { CallbackParameters } from '../types'
 import { switchToRequiredAccount } from '../utils'
 import { getSdkError } from '@walletconnect/utils'
+import { Platform } from '@core/app'
 
 export async function handleSignMessage(
     params: unknown,
@@ -28,6 +29,7 @@ export async function handleSignMessage(
         return
     }
     const message = Converter.hexToUtf8(hexMessage)
+    Platform.focusWindow()
 
     try {
         const account = await switchToRequiredAccount(accountAddress, chain)


### PR DESCRIPTION
## Summary

This PR fixes the focusing when app is minimized or not focused and the focusWindow method is called, it also changes when the focusWindow method is called, making Bloom only open when popup is opened.

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
