### PR TITLE
fix: importing erc 20 tokens

### DIFF
--- a/packages/shared/src/lib/auxiliary/wallet-connect/handlers/wallet_watchAsset.handler.ts
+++ b/packages/shared/src/lib/auxiliary/wallet-connect/handlers/wallet_watchAsset.handler.ts
@@ -7,6 +7,7 @@ import { addNewTrackedTokenToActiveProfile } from '@core/wallet/actions'
 import { TokenStandard, TokenTrackingStatus } from '@core/token/enums'
 import { IConnectedDapp } from '../interface'
 import { localize } from '@core/i18n'
+import { NftStandard } from '@core/nfts/enums'
 
 interface WatchAssetParams {
     type: EvmAssetStandard
@@ -24,7 +25,7 @@ export async function handleWatchAsset(
     chain: IChain,
     responseCallback: (params: CallbackParameters) => void
 ): Promise<void> {
-    if (params.type !== 'ERC20' && params.type !== 'ERC721') {
+    if (params.type !== TokenStandard.Erc20 && params.type !== NftStandard.Erc721) {
         responseCallback({ error: getSdkError('UNSUPPORTED_METHODS') })
         return
     }
@@ -63,7 +64,7 @@ async function getAssetInfo(
     chain: IChain
 ): Promise<{ name: string; decimals: number; symbol: string } | undefined> {
     switch (type) {
-        case 'ERC20': {
+        case TokenStandard.Erc20: {
             const { address } = options
             const contract = chain.getContract(ContractType.Erc20, address)
             const name = options.name ? options.name : await contract?.methods.name().call()
@@ -72,7 +73,7 @@ async function getAssetInfo(
 
             return { name: name, decimals, symbol }
         }
-        case 'ERC721':
+        case NftStandard.Erc721:
             // TODO
             break
         default:
@@ -91,7 +92,7 @@ function trackAsset(
     networkId: NetworkId
 ): void {
     switch (type) {
-        case 'ERC20':
+        case TokenStandard.Erc20:
             addNewTrackedTokenToActiveProfile(
                 networkId,
                 address,
@@ -99,7 +100,7 @@ function trackAsset(
                 TokenTrackingStatus.ManuallyTracked
             )
             break
-        case 'ERC721':
+        case NftStandard.Erc721:
             // TODO
             break
         default:

--- a/packages/shared/src/lib/core/nfts/enums/nft-standard.enum.ts
+++ b/packages/shared/src/lib/core/nfts/enums/nft-standard.enum.ts
@@ -1,4 +1,4 @@
 export enum NftStandard {
     Irc27 = 'IRC27',
-    Erc721 = 'ERC-721',
+    Erc721 = 'ERC721',
 }

--- a/packages/shared/src/lib/core/token/enums/token-standard.enum.ts
+++ b/packages/shared/src/lib/core/token/enums/token-standard.enum.ts
@@ -1,5 +1,5 @@
 export enum TokenStandard {
     BaseToken = 'BASE_TOKEN',
     Irc30 = 'IRC30',
-    Erc20 = 'ERC-20',
+    Erc20 = 'ERC20',
 }

--- a/packages/shared/src/lib/core/wallet/tests/getOutputParameters.test.ts
+++ b/packages/shared/src/lib/core/wallet/tests/getOutputParameters.test.ts
@@ -77,7 +77,7 @@ jest.mock('@core/token/stores/persisted-tokens.store', () => ({
 }))
 
 jest.mock('@core/token/actions/getAccountTokensForAccount', () => ({
-    getAccountTokensForSelectedAccount: jest.fn((_) => {
+    getAccountTokensForAccount: jest.fn((_) => {
         return {
             [SupportedNetworkId.Testnet]: {
                 baseCoin: PERSISTED_ASSET_SHIMMER,


### PR DESCRIPTION
## Summary

Revert changes to the standard notation to fix showing persisted ERC20 tokens. The following text contains the motivation behind the fix:

We persisted the standard as ERC20 instead of ERC-20, but we changed this 3 weeks ago in PR 1588. I see two options to fix this.

1. We revert the changes we made, so that we keep persisting the standard as ERC20 instead of ERC-20. This means we have to replace the hyphen in the response we get from blockscout (relevant commit: https://github.com/bloomwalletio/bloom/pull/1588/commits/b3141949e04d6c3a2331f38b7b5c36f8b1ba753c). An added benefit is consistency with MIP (for wallet_watchAsset), and IRC tokens.

2. We write a migration script to update the persistedToken store and add some versioning to it.

We opted for solution 1.

## Testing

### Platforms

> Please select any platforms where your changes have been tested.

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows

### Instructions

> Please describe the specific instructions, configurations, and/or test cases necessary to **test and verify** that your changes work as intended.

...

## Checklist

> Please tick the following boxes that are relevant to your changes.

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
