### PR TITLE
fix: Transak currency validation and defaultCryptoAmount

### DIFF
--- a/packages/desktop/lib/electron/managers/transak.manager.ts
+++ b/packages/desktop/lib/electron/managers/transak.manager.ts
@@ -171,7 +171,7 @@ export default class TransakManager implements ITransakManager {
         const { address, currency, service } = data
         const apiKey = process.env.TRANSAK_API_KEY
 
-        if (Object.values(MarketCurrency).includes(currency as MarketCurrency)) {
+        if (!Object.values(MarketCurrency).includes(currency as MarketCurrency)) {
             throw new Error('Invalid Transak currency')
         }
 
@@ -182,7 +182,7 @@ export default class TransakManager implements ITransakManager {
         const queryParams = buildQueryParametersFromObject({
             apiKey,
             defaultFiatCurrency: currency,
-            defaultFiatAmount: 100,
+            defaultCryptoAmount: 100,
             walletAddress: address,
             productsAvailed: service,
             cryptoCurrencyCode: 'IOTA',


### PR DESCRIPTION
## Summary

This fixes the Transak currency validation and change the default fiat amount to default crypto amount because the default fiat amount will not always reach the minimum value needed (e.g. BRL minimum amount is 148)

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
