### PR TITLE
chore: adds production & staging key for Transak in build action

### DIFF
--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -117,6 +117,14 @@ jobs:
               run: echo "DEBUG=electron-builder" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
               if: inputs.os == 'windows-2022'
 
+            - name: Set Transak API key
+              run: |
+                if [ "${{ inputs.stage }}" = "prod" ]; then
+                  echo "TRANSAK_API_KEY=${{ secrets.TRANSAK_API_KEY_PRODUCTION }}" >> $GITHUB_ENV
+                else
+                  echo "TRANSAK_API_KEY=${{ secrets.TRANSAK_API_KEY_STAGING }}" >> $GITHUB_ENV
+                fi
+
             - name: Set up .npmrc file to use GitHub Packages
               run: |
                   echo "@bloomwalletio:registry=https://npm.pkg.github.com/" >> .npmrc
@@ -137,7 +145,6 @@ jobs:
               env:
                   HARDCODE_NODE_ENV: true
                   AMPLITUDE_API_KEY: ${{ secrets.AMPLITUDE_API_KEY }}
-                  TRANSAK_API_KEY: ${{ secrets.TRANSAK_API_KEY }}
 
             - name: Build signed Electron app (MacOS)
               run: yarn compile:${STAGE}:mac


### PR DESCRIPTION
## Summary

Adds a step in build action for choosing between production & staging Transak API keys depending on the stage that it is being built on

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
