### PR TITLE
fix: remove USD from Transak

### DIFF
--- a/packages/desktop/lib/electron/managers/transak.manager.ts
+++ b/packages/desktop/lib/electron/managers/transak.manager.ts
@@ -249,6 +249,7 @@ export default class TransakManager implements ITransakManager {
             disableWalletAddressForm: true,
             isFeeCalculationHidden: true,
             disablePaymentMethods: ['apple_pay', 'google_pay'],
+            excludeFiatCurrencies: 'USD',
             colorMode,
         }
 

--- a/packages/desktop/views/dashboard/buy-sell/views/BuySellMainView.svelte
+++ b/packages/desktop/views/dashboard/buy-sell/views/BuySellMainView.svelte
@@ -65,16 +65,17 @@
     }
 
     function getDefaultFiatAmount(currency: MarketCurrency): number {
+        const DEFAULT_FIAT_AMOUNT = 1000
         switch (currency) {
             case MarketCurrency.Usd:
             case MarketCurrency.Eur:
             case MarketCurrency.Gbp:
-                return 100
+                return DEFAULT_FIAT_AMOUNT
             default: {
                 const conversionRate =
                     $marketCoinPrices[MarketCoinId.Iota]?.[currency] /
                     $marketCoinPrices[MarketCoinId.Iota]?.[MarketCurrency.Usd]
-                const fiatAmount = 100 * conversionRate
+                const fiatAmount = DEFAULT_FIAT_AMOUNT * conversionRate
                 const roundedAmount = customRound(fiatAmount)
                 return roundedAmount
             }


### PR DESCRIPTION
## Summary

This removes the USD currency from Transak as the Zero Hash does not support IOTA.

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [ ] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
