### PR TITLE
fix: change GHA node version from 20.x to 20.10.0

### DIFF
--- a/.github/workflows/ci.lint.yml
+++ b/.github/workflows/ci.lint.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 20.x
+                  node-version: 20.10.0
 
             - name: Set up .npmrc file to use GitHub Packages
               run: |
@@ -38,7 +38,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 20.x
+                  node-version: 20.10.0
 
             - name: Set up .npmrc file to use GitHub Packages
               run: |

--- a/.github/workflows/ci.test.yml
+++ b/.github/workflows/ci.test.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 20.x
+                  node-version: 20.10.0
 
             - name: Set up .npmrc file to use GitHub Packages
               run: |

--- a/.github/workflows/ci.ts.yml
+++ b/.github/workflows/ci.ts.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 20.x
+                  node-version: 20.10.0
 
             - name: Set up .npmrc file to use GitHub Packages
               run: |

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -35,7 +35,7 @@ jobs:
             - name: Setup NodeJS
               uses: actions/setup-node@v1
               with:
-                  node-version: 20.x
+                  node-version: 20.10.0
 
             # Used to read the `binding.gyp` file from `@iota/sdk`
             - name: Set up Python 3.10


### PR DESCRIPTION
## Summary

Fixes node version for GHA as 20.10.0 because build on Windows is throwing errors on 20.12.2

[GitHub Action Build Test](https://github.com/bloomwalletio/bloom/actions/runs/8740196584)

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

## Checklist

-   [ ] I have followed the contribution guidelines for this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [ ] I have verified that new and existing unit tests pass locally with my changes
-   [ ] I have verified that my latest changes pass CI workflows for testing and linting
-   [ ] I have made corresponding changes to the documentation
