### PR TITLE
feat: mark notification as read if visible

### DIFF
--- a/packages/desktop/views/dashboard/components/NotificationsButton.svelte
+++ b/packages/desktop/views/dashboard/components/NotificationsButton.svelte
@@ -85,6 +85,8 @@
     function onVisibilityChange({ detail }: CustomEvent): void {
         if (detail.visible) {
             toggleObserve()
+        } else {
+            notificationsManager.updateAllSubscriptionsAndNotifications()
         }
     }
 </script>

--- a/packages/desktop/views/dashboard/components/NotificationsButton.svelte
+++ b/packages/desktop/views/dashboard/components/NotificationsButton.svelte
@@ -17,7 +17,6 @@
 
     let selectedTab = TABS[0]
 
-    const MAX_AMOUNT_OF_NOTIFICATIONS = 7
     const evmNetwork = getEvmNetwork(SupportedNetworkId.Ethereum)
     const notifications = notificationsManager.notificationsPerSubscription
     $: notificationsToDisplay = Object.keys($notifications)
@@ -28,7 +27,6 @@
             }))
         )
         .sort((a, b) => b.sentAt - a.sentAt)
-        .slice(0, MAX_AMOUNT_OF_NOTIFICATIONS)
 
     let anchor: HTMLElement | undefined = undefined
 
@@ -77,14 +75,13 @@
             <div class="w-full p-4">
                 <Tabs bind:selectedTab tabs={TABS} />
             </div>
-            {#each notificationsToDisplay as notification}
-                <NotificationTile {notification} subscriptionTopic={notification.subscriptionTopic} />
-            {/each}
-            {#if Object.values($notifications).flat().length > MAX_AMOUNT_OF_NOTIFICATIONS}
-                <div class="p-3 w-full">
-                    <Button size="xs" text={localize('views.dashboard.dappNotifications.viewAll')} width="full" />
-                </div>
-            {/if}
+            <ul
+                class="flex flex-col divide-y divide-solid divide-stroke dark:divide-stroke-dark w-full max-h-[75vh] overflow-y-scroll"
+            >
+                {#each notificationsToDisplay as notification}
+                    <li><NotificationTile {notification} subscriptionTopic={notification.subscriptionTopic} /></li>
+                {/each}
+            </ul>
         {:else if !isAtLeast1AccountRegistered}
             <div class="px-3 py-8 w-full flex flex-col gap-4 items-center">
                 <Text type="body2" align="center">{localize('views.dashboard.dappNotifications.notEnabledHint')}</Text>

--- a/packages/desktop/views/dashboard/components/NotificationsButton.svelte
+++ b/packages/desktop/views/dashboard/components/NotificationsButton.svelte
@@ -65,7 +65,7 @@
                 }
             })
         },
-        { threshold: 1 }
+        { threshold: 0.5 }
     )
 
     function observe(node: HTMLElement): void {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,7 +5,7 @@
     "author": "Bloom Labs Ltd <contact@bloomwallet.io>",
     "license": "PolyForm Strict License 1.0.0",
     "dependencies": {
-        "@bloomwalletio/ui": "0.21.1",
+        "@bloomwalletio/ui": "0.21.2",
         "@ethereumjs/common": "4.3.0",
         "@ethereumjs/rlp": "5.0.2",
         "@ethereumjs/tx": "5.3.0",

--- a/packages/shared/src/lib/auxiliary/wallet-connect/notifications/classes/notificationsManager.class.ts
+++ b/packages/shared/src/lib/auxiliary/wallet-connect/notifications/classes/notificationsManager.class.ts
@@ -257,16 +257,18 @@ export class NotificationsManager {
     }
 
     markAsRead(notificationIds: string[], topic: string): void {
-        this.notifyClient?.markNotificationsAsRead({ notificationIds, topic })
-        this.notificationsPerSubscription.update((state) => {
-            state[topic] = state[topic].map((notification) => {
-                if (notificationIds.includes(notification.id)) {
-                    notification.isRead = true
-                }
-                return notification
-            })
-            return state
-        })
+        void this.notifyClient?.markNotificationsAsRead({ notificationIds, topic })
+    }
+
+    async updateAllSubscriptionsAndNotifications(): Promise<void> {
+        if (!this.notifyClient) {
+            return
+        }
+
+        const activeSubscriptions = Object.values(this.notifyClient.getActiveSubscriptions())
+        this.updateSubscriptionsPerAddress(activeSubscriptions)
+
+        await this.updateNotificationsForSubscriptions(activeSubscriptions)
     }
 }
 

--- a/packages/shared/src/lib/auxiliary/wallet-connect/notifications/classes/notificationsManager.class.ts
+++ b/packages/shared/src/lib/auxiliary/wallet-connect/notifications/classes/notificationsManager.class.ts
@@ -255,6 +255,19 @@ export class NotificationsManager {
 
         await this.notifyClient?.subscribe({ appDomain, account: networkAddress })
     }
+
+    markAsRead(notificationIds: string[], topic: string): void {
+        this.notifyClient?.markNotificationsAsRead({ notificationIds, topic })
+        this.notificationsPerSubscription.update((state) => {
+            state[topic] = state[topic].map((notification) => {
+                if (notificationIds.includes(notification.id)) {
+                    notification.isRead = true
+                }
+                return notification
+            })
+            return state
+        })
+    }
 }
 
 export const notificationsManager = new NotificationsManager()

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,10 +348,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bloomwalletio/ui@0.21.1":
-  version "0.21.1"
-  resolved "https://npm.pkg.github.com/download/@bloomwalletio/ui/0.21.1/ce60ed69ad083f7ebc27164cc2fa69c8bf1a041f#ce60ed69ad083f7ebc27164cc2fa69c8bf1a041f"
-  integrity sha512-1//FX06CFUvv2SXUHQGZwQ9Y8FbO/Irj8cYO3cVXNbQHiM93UCtxgb/jYmryaOSHBrhH7OtrzDt+/0Hg88BA1w==
+"@bloomwalletio/ui@0.21.2":
+  version "0.21.2"
+  resolved "https://npm.pkg.github.com/download/@bloomwalletio/ui/0.21.2/ba3ac309e94c24bc31baaf1ac0d226ec1f8d9eaa#ba3ac309e94c24bc31baaf1ac0d226ec1f8d9eaa"
+  integrity sha512-ZKZxjjPkQaTrctjqRWK3K2QF064hmVaZ6IsVvpMkJ/nCdlGg/YEW1bXQ/Pe02F3LObhmKDSyruDaotxGwz6dMA==
   dependencies:
     "@floating-ui/dom" "1.4.3"
     "@popperjs/core" "2.11.8"


### PR DESCRIPTION
## Summary

⚠️ depends on https://github.com/bloomwalletio/bloom-ui/pull/326

Uses Intersection Observer API for observing the notification's elements visibility and to mark them as read.
It was necessary to add `visibilityChange` on Popover to recalculate the observed targets' intersection status every time the Popover visibility is changed.

closes #2524 

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [x] I have made corresponding changes to the documentation
