### PR TITLE
fix: remove hidden/scam nfts in collections

### DIFF
--- a/packages/desktop/views/dashboard/collectibles/components/CollectionDetails.svelte
+++ b/packages/desktop/views/dashboard/collectibles/components/CollectionDetails.svelte
@@ -5,7 +5,7 @@
 
     export let collectionId: string
 
-    $: nfts = $ownedNfts.filter((nft) => nft.collectionId === collectionId)
+    $: nfts = $ownedNfts.filter((nft) => nft.collectionId === collectionId && !nft.hidden && !nft.isScam)
 
     onDestroy(() => {
         $selectedCollectionId = undefined

--- a/packages/desktop/views/dashboard/collectibles/components/CollectionsGalleryItem.svelte
+++ b/packages/desktop/views/dashboard/collectibles/components/CollectionsGalleryItem.svelte
@@ -14,7 +14,7 @@
     }
 
     $: collection = $persistedCollections[collectionId]
-    $: nfts = $ownedNfts.filter((nft) => nft.collectionId === collectionId)
+    $: nfts = $ownedNfts.filter((nft) => nft.collectionId === collectionId && !nft.hidden && !nft.isScam)
 </script>
 
 {#if collection && nfts.length > 0}

--- a/packages/desktop/views/dashboard/collectibles/views/CollectionsGalleryView.svelte
+++ b/packages/desktop/views/dashboard/collectibles/views/CollectionsGalleryView.svelte
@@ -11,17 +11,18 @@
 
     let queriedCollectionsIds: string[] = []
 
-    $: collectionsIds = new Set(
-        $ownedNfts
-            ?.map((nft) => nft.collectionId)
-            .filter((collectionId) => collectionId && $persistedCollections[collectionId])
-    )
+    $: collectionsIds = $ownedNfts?.reduce((set, nft) => {
+        if (!nft.hidden && !nft.isScam && nft.collectionId && $persistedCollections[nft.collectionId]) {
+            set.add(nft.collectionId)
+        }
+        return set
+    }, new Set<string>())
 
     $: $collectionsSearchTerm, collectionsIds, setQueriedCollectionsIds()
 
     function setQueriedCollectionsIds(): void {
         queriedCollectionsIds = Array.from(collectionsIds)
-            .filter((collectionId) => isVisibleCollection($persistedCollections[collectionId]))
+            ?.filter((collectionId) => isVisibleCollection($persistedCollections[collectionId]))
             .sort((collectionId1, collectionId2) =>
                 $persistedCollections[collectionId1]?.name
                     .toLowerCase()


### PR DESCRIPTION
## Summary

This PR makes scam/hidden NFTs not show in collections

## Testing

### Platforms

-   **Desktop**
    -   [ ] MacOS
    -   [ ] Linux
    -   [x] Windows

## Checklist

-   [x] I have followed the contribution guidelines for this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have added or modified tests that prove my changes work as intended
-   [x] I have verified that new and existing unit tests pass locally with my changes
-   [x] I have verified that my latest changes pass CI workflows for testing and linting
-   [x] I have made corresponding changes to the documentation
